### PR TITLE
vml-get-arch: use geo.mirror.pkgbuild.com

### DIFF
--- a/files/get-url-progs/vml-get-arch
+++ b/files/get-url-progs/vml-get-arch
@@ -7,6 +7,6 @@
 # apropriate item. Do not forget to update `change` section to keep
 # `get-url-prog` from updating.
 
-url="https://mirror.pkgbuild.com/images/latest/"
+url="https://geo.mirror.pkgbuild.com/images/latest/"
 name="$(curl "$url" | sed -n -E 's/.*href="(.*cloudimg.*\.qcow2)".*/\1/p' | sort -rV | head -1)"
 echo "$url$name"


### PR DESCRIPTION
geo.mirror.pkgbuild.com is a GeoDNS mirror that points to sponsored mirrors.

This avoids the usage of Arch's infrastructure (mirror.pkgbuild.com) for large downloads.
See https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/522 for details.